### PR TITLE
Colab Inference Notebook

### DIFF
--- a/inference.ipynb
+++ b/inference.ipynb
@@ -1,0 +1,71 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": [],
+      "machine_shape": "hm",
+      "gpuType": "L4",
+      "authorship_tag": "ABX9TyMkPvEHcvZ84lF6ESOuPfMJ",
+      "include_colab_link": true
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    },
+    "accelerator": "GPU"
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "view-in-github",
+        "colab_type": "text"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/usamireko/ACE-Step/blob/main/inference.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "cellView": "form",
+        "id": "EB_ztF9xch5s"
+      },
+      "outputs": [],
+      "source": [
+        "#@title Install and Download\n",
+        "!wget -O /content/mini.sh https://repo.anaconda.com/miniconda/Miniconda3-py310_25.1.1-2-Linux-x86_64.sh\n",
+        "!chmod +x /content/mini.sh\n",
+        "!bash /content/mini.sh -b -f -p /usr/local\n",
+        "!conda install -q -y jupyter\n",
+        "!conda install -q -y google-colab -c conda-forge\n",
+        "!python -m ipykernel install --name \"py310\" --user\n",
+        "!git clone https://github.com/usamireko/ACE-Step\n",
+        "%cd /content/ACE-Step\n",
+        "!pip install -r requirements.txt\n",
+        "!pip install huggingface-hub numpy==1.26.0\n",
+        "!huggingface-cli download ACE-Step/ACE-Step-v1-3.5B --local-dir /content/ACE-Step/checkpoints --local-dir-use-symlinks False"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "#@title Run Gradio UI\n",
+        "bf16 = True # @param {\"type\":\"boolean\"}\n",
+        "\n",
+        "!python app.py --checkpoint_path ./checkpoints/ --port 7865 --device_id 0 --share true --bf16 {bf16}"
+      ],
+      "metadata": {
+        "cellView": "form",
+        "id": "0m835b3ZecQW"
+      },
+      "execution_count": null,
+      "outputs": []
+    }
+  ]
+}


### PR DESCRIPTION
Made a colab notebook that aims to be easy to use by just giving clicks to the cells to run it.

numpy 1.26.0 is being installed due to errors appearing when trying to open the UI on Colab.

`ValueError: numpy.dtype size changed, may indicate binary incompatibility. Expected 96 from C header, got 88 from PyObject`

I´ve seen that before and I suspect it has something to do with pypinyin, and the way it was solved in the past was by downgrading numpy to 1.26.0, seems that this is also the case here.