### PR TITLE
Fix: Correct save_path handling in ACEStepPipeline

### DIFF
--- a/acestep/pipeline_ace_step.py
+++ b/acestep/pipeline_ace_step.py
@@ -1329,8 +1329,8 @@ class ACEStepPipeline:
         pred_wavs = [pred_wav.cpu().float() for pred_wav in pred_wavs]
         for i in tqdm(range(bs)):
             output_audio_path = self.save_wav_file(
-                pred_wavs[i], i, sample_rate=sample_rate
-            )
+                pred_wavs[i], i, save_path=save_path, sample_rate=sample_rate, format=format
+            )            
             output_audio_paths.append(output_audio_path)
         return output_audio_paths
 
@@ -1341,15 +1341,19 @@ class ACEStepPipeline:
             logger.warning("save_path is None, using default path ./outputs/")
             base_path = f"./outputs"
             ensure_directory_exists(base_path)
+            output_path_wav = (
+                f"{base_path}/output_{time.strftime('%Y%m%d%H%M%S')}_{idx}.wav"
+            )
         else:
-            base_path = save_path
-            ensure_directory_exists(base_path)
-
-        output_path_wav = (
-            f"{base_path}/output_{time.strftime('%Y%m%d%H%M%S')}_{idx}.wav"
-        )
+            ensure_directory_exists(os.path.dirname(save_path))
+            if os.path.isdir(save_path):
+                logger.info(f"Provided save_path '{save_path}' is a directory. Appending timestamped filename.")
+                output_path_wav = os.path.join(save_path, f"output_{time.strftime('%Y%m%d%H%M%S')}_{idx}.wav")
+            else:
+                output_path_wav = save_path
+        
         target_wav = target_wav.float()
-        print(target_wav)
+        logger.info(f"Saving audio to {output_path_wav}")
         torchaudio.save(
             output_path_wav, target_wav, sample_rate=sample_rate, format=format
         )


### PR DESCRIPTION
Amazing work on ACE-step. 

Currently, in `ACEStepPipeline.__call__` - `latents2audio` is not sending `save_path` to `save_wav_file`. This results in always saving in a local `./outputs/` directory with a timestamped filename. 

I also added support for save_path being a full named file path. Now save_path is working as:
*   `save_path=None` -> Saves to `./outputs/output_{timestamp}_{idx}.wav`
*   `save_path="/path/to/dir/"` -> Saves to `/path/to/dir/output_{timestamp}_{idx}.wav`
*   `save_path="/path/to/file.wav"` -> Saves to `/path/to/file.wav`