### PR TITLE
Fix: Correct model checkpoint download paths (#68)

### DIFF
--- a/acestep/pipeline_ace_step.py
+++ b/acestep/pipeline_ace_step.py
@@ -151,10 +151,6 @@ class ACEStepPipeline:
             and os.path.exists(
                 os.path.join(text_encoder_model_path, "special_tokens_map.json")
             )
-            and os.path.exists(
-                os.path.join(text_encoder_model_path, "tokenizer_config.json")
-            )
-            and os.path.exists(os.path.join(text_encoder_model_path, "tokenizer.json"))
         )
 
         if not files_exist:
@@ -163,84 +159,111 @@ class ACEStepPipeline:
             )
 
             # download music dcae model
-            os.makedirs(dcae_model_path, exist_ok=True)
             hf_hub_download(
                 repo_id=REPO_ID,
                 subfolder="music_dcae_f8c8",
                 filename="config.json",
-                cache_dir=checkpoint_dir,
+                local_dir=checkpoint_dir,
+                local_dir_use_symlinks=False,
             )
             hf_hub_download(
                 repo_id=REPO_ID,
                 subfolder="music_dcae_f8c8",
                 filename="diffusion_pytorch_model.safetensors",
-                cache_dir=checkpoint_dir,
+                local_dir=checkpoint_dir,
+                local_dir_use_symlinks=False,
             )
 
             # download vocoder model
-            os.makedirs(vocoder_model_path, exist_ok=True)
             hf_hub_download(
                 repo_id=REPO_ID,
                 subfolder="music_vocoder",
                 filename="config.json",
-                cache_dir=checkpoint_dir,
+                local_dir=checkpoint_dir,
+                local_dir_use_symlinks=False,
             )
             hf_hub_download(
                 repo_id=REPO_ID,
                 subfolder="music_vocoder",
                 filename="diffusion_pytorch_model.safetensors",
-                cache_dir=checkpoint_dir,
+                local_dir=checkpoint_dir,
+                local_dir_use_symlinks=False,
             )
 
             # download ace_step transformer model
-            os.makedirs(ace_step_model_path, exist_ok=True)
             hf_hub_download(
                 repo_id=REPO_ID,
                 subfolder="ace_step_transformer",
                 filename="config.json",
-                cache_dir=checkpoint_dir,
+                local_dir=checkpoint_dir,
+                local_dir_use_symlinks=False,
             )
             hf_hub_download(
                 repo_id=REPO_ID,
                 subfolder="ace_step_transformer",
                 filename="diffusion_pytorch_model.safetensors",
-                cache_dir=checkpoint_dir,
+                local_dir=checkpoint_dir,
+                local_dir_use_symlinks=False,
             )
 
             # download text encoder model
-            os.makedirs(text_encoder_model_path, exist_ok=True)
+            # os.makedirs(text_encoder_model_path, exist_ok=True) # hf_hub_download should create subdirectories
             hf_hub_download(
                 repo_id=REPO_ID,
                 subfolder="umt5-base",
                 filename="config.json",
-                cache_dir=checkpoint_dir,
+                local_dir=checkpoint_dir,
+                local_dir_use_symlinks=False,
             )
             hf_hub_download(
                 repo_id=REPO_ID,
                 subfolder="umt5-base",
                 filename="model.safetensors",
-                cache_dir=checkpoint_dir,
+                local_dir=checkpoint_dir,
+                local_dir_use_symlinks=False,
             )
             hf_hub_download(
                 repo_id=REPO_ID,
                 subfolder="umt5-base",
                 filename="special_tokens_map.json",
                 local_dir=checkpoint_dir,
+                local_dir_use_symlinks=False,
             )
             hf_hub_download(
                 repo_id=REPO_ID,
                 subfolder="umt5-base",
                 filename="tokenizer_config.json",
                 local_dir=checkpoint_dir,
+                local_dir_use_symlinks=False,
             )
             hf_hub_download(
                 repo_id=REPO_ID,
                 subfolder="umt5-base",
                 filename="tokenizer.json",
                 local_dir=checkpoint_dir,
+                local_dir_use_symlinks=False,
             )
 
-            logger.info("Models downloaded")
+            # Verify files were downloaded correctly
+            if not all([
+                os.path.exists(os.path.join(dcae_model_path, "config.json")),
+                os.path.exists(os.path.join(dcae_model_path, "diffusion_pytorch_model.safetensors")),
+                os.path.exists(os.path.join(vocoder_model_path, "config.json")),
+                os.path.exists(os.path.join(vocoder_model_path, "diffusion_pytorch_model.safetensors")),
+                os.path.exists(os.path.join(ace_step_model_path, "config.json")),
+                os.path.exists(os.path.join(ace_step_model_path, "diffusion_pytorch_model.safetensors")),
+                os.path.exists(os.path.join(text_encoder_model_path, "config.json")),
+                os.path.exists(os.path.join(text_encoder_model_path, "model.safetensors")),
+                os.path.exists(os.path.join(text_encoder_model_path, "special_tokens_map.json")),
+            ]):
+                logger.error("Failed to download all required model files. Please check your internet connection and try again.")
+                logger.info(f"DCAE model path: {dcae_model_path}, files exist: {os.path.exists(os.path.join(dcae_model_path, 'config.json'))}")
+                logger.info(f"Vocoder model path: {vocoder_model_path}, files exist: {os.path.exists(os.path.join(vocoder_model_path, 'config.json'))}")
+                logger.info(f"ACE-Step model path: {ace_step_model_path}, files exist: {os.path.exists(os.path.join(ace_step_model_path, 'config.json'))}")
+                logger.info(f"Text encoder model path: {text_encoder_model_path}, files exist: {os.path.exists(os.path.join(text_encoder_model_path, 'config.json'))}")
+                raise RuntimeError("Model download failed. See logs for details.")
+
+            logger.info("Models downloaded successfully")
 
         dcae_checkpoint_path = dcae_model_path
         vocoder_checkpoint_path = vocoder_model_path


### PR DESCRIPTION
Addresses issue #68.

**Description of Problem:**

When running the ACE-Step application, model checkpoints were not being saved to the correct cache subdirectories (e.g., `C:\Users\RM\.cache/ace-step/checkpoints\music_dcae_f8c8`), despite CLI indications of download activity. This led to an `OSError` when the application attempted to load models, as essential files like `config.json` were missing from their expected locations.

**Summary of Changes:**

This PR modifies `acestep/pipeline_ace_step.py` to correct the download paths for all model components:
- Ensures `hf_hub_download` uses the main `checkpoint_dir` as `local_dir` and specifies the target `subfolder` correctly. This prevents files from being saved in an unintended nested directory structure.
- Removes redundant `os.makedirs` calls for model subdirectories, as `hf_hub_download` handles their creation.

These changes ensure that all model files are downloaded and cached in the correct locations, allowing the application to load them successfully.

**To Test:**
1. Clear the existing checkpoint cache directory (e.g., `C:\Users\RM\.cache\ace-step\checkpoints`).
2. Run the application (e.g., `acestep --port 7865`).
3. Verify that all models download into their respective subfolders within the cache and the application starts without `OSError` or `RuntimeError` related to model loading.