### PR TITLE
Fix: Dockerfile for ModuleNotFoundError and Volume Write Permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,10 @@ RUN pip3 install --no-cache-dir --upgrade pip && \
     pip3 install --no-cache-dir -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cu126
 RUN pip3 install --no-cache-dir .
 
+# Ensure target directories for volumes exist and have correct initial ownership
+RUN mkdir -p /app/outputs /app/checkpoints /app/logs && \
+    chown -R appuser:appuser /app/outputs /app/checkpoints /app/logs
+
 # Change ownership of app files to appuser
 RUN chown -R appuser:appuser /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ RUN git clone https://github.com/ace-step/ACE-Step.git .
 RUN pip3 install --no-cache-dir --upgrade pip && \
     pip3 install --no-cache-dir hf_transfer peft && \
     pip3 install --no-cache-dir -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cu126
+RUN pip3 install --no-cache-dir .
 
 # Change ownership of app files to appuser
 RUN chown -R appuser:appuser /app


### PR DESCRIPTION
This PR addresses two issues encountered when running the application via `docker compose`: 

 **ModuleNotFoundError for 'acestep':** The Dockerfile was missing a step to install the `acestep` package itself using `pip install .` This has been added after dependency installation.

**Volume Write Permissions Error:** The application failed to write output files (e.g., to `./outputs/`) due to permission errors. This was resolved by explicitly creating `/app/outputs`, `/app/checkpoints`, and `/app/logs` and setting their ownership to the `appuser` before switching to that user in the Dockerfile. 