### PR TITLE
Add output directory creation in create_text2music_ui function

### DIFF
--- a/acestep/ui/components.py
+++ b/acestep/ui/components.py
@@ -96,6 +96,7 @@ def create_text2music_ui(
     with gr.Row(equal_height=True):
         curr_file_dir = os.path.dirname(__file__)
         output_file_dir = os.path.join(curr_file_dir, "..", "..", "outputs")
+        os.makedirs(output_file_dir, exist_ok=True)
         json_files = [f for f in os.listdir(output_file_dir) if f.endswith('.json')]
         json_files.sort(reverse=True, key=lambda x: int(x.split('_')[1]))
         output_files = gr.Dropdown(choices=json_files, label="Select previous generated input params", scale=9, interactive=True)


### PR DESCRIPTION
Fixed first-time installation bug where starting fails due to directory not being automatically created.