### PR TITLE
add auto outputs folder creation in components.py

### DIFF
--- a/acestep/ui/components.py
+++ b/acestep/ui/components.py
@@ -96,6 +96,7 @@ def create_text2music_ui(
     with gr.Row(equal_height=True):
         curr_file_dir = os.path.dirname(__file__)
         output_file_dir = os.path.join(curr_file_dir, "..", "..", "outputs")
+        if not os.path.isdir(output_file_dir): os.makedirs(output_file_dir)
         json_files = [f for f in os.listdir(output_file_dir) if f.endswith('.json')]
         json_files.sort(reverse=True, key=lambda x: int(x.split('_')[1]))
         output_files = gr.Dropdown(choices=json_files, label="Select previous generated input params", scale=9, interactive=True)


### PR DESCRIPTION
<h2>Added the functionality to automatically create the outputs folder if it doesn't exist at line 99</h2>

<h1>REASON</h1>
I was getting the following error:<br>
```
Traceback (most recent call last):
  File "/home/zeus/miniconda3/envs/cloudspace/bin/acestep", line 33, in <module>
    sys.exit(load_entry_point('ace-step', 'console_scripts', 'acestep')())
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/click/core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/click/core.py", line 1082, in main
    rv = self.invoke(ctx)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/click/core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
  File "/teamspace/studios/this_studio/ACE-Step/acestep/gui.py", line 71, in main
    demo = create_main_demo_ui(
  File "/teamspace/studios/this_studio/ACE-Step/acestep/ui/components.py", line 980, in create_main_demo_ui
    create_text2music_ui(
  File "/teamspace/studios/this_studio/ACE-Step/acestep/ui/components.py", line 99, in create_text2music_ui
    json_files = [f for f in os.listdir(output_file_dir) if f.endswith('.json')]
FileNotFoundError: [Errno 2] No such file or directory: '/teamspace/studios/this_studio/ACE-Step/acestep/ui/../../outputs'
```
<br>
<h4>So I fixed it by adding a new line `if not os.path.isdir(output_file_dir): os.makedirs(output_file_dir)` which fixed the issue for me </h4>