### PR TITLE
Improve Docker output paths and non-Docker compatibility

### DIFF
--- a/acestep/ui/components.py
+++ b/acestep/ui/components.py
@@ -94,8 +94,13 @@ def create_text2music_ui(
 ):
 
     with gr.Row(equal_height=True):
-        curr_file_dir = os.path.dirname(__file__)
-        output_file_dir = os.path.join(curr_file_dir, "..", "..", "outputs")
+        # curr_file_dir = os.path.dirname(__file__) # Original path logic
+        # output_file_dir = os.path.join(curr_file_dir, "..", "..", "outputs") # Original path logic
+        # Get base output directory from environment variable, defaulting to CWD-relative 'outputs'.
+        # This default (./outputs) is suitable for non-Docker local development.
+        # For Docker, the ACE_OUTPUT_DIR environment variable should be set (e.g., to /app/outputs).
+        _output_base_dir = os.environ.get("ACE_OUTPUT_DIR", "./outputs")
+        output_file_dir = os.path.join(_output_base_dir, "text2music")
         if not os.path.isdir(output_file_dir):
             os.makedirs(output_file_dir, exist_ok=True)
         json_files = [f for f in os.listdir(output_file_dir) if f.endswith('.json')]

--- a/acestep/ui/components.py
+++ b/acestep/ui/components.py
@@ -94,8 +94,6 @@ def create_text2music_ui(
 ):
 
     with gr.Row(equal_height=True):
-        # curr_file_dir = os.path.dirname(__file__) # Original path logic
-        # output_file_dir = os.path.join(curr_file_dir, "..", "..", "outputs") # Original path logic
         # Get base output directory from environment variable, defaulting to CWD-relative 'outputs'.
         # This default (./outputs) is suitable for non-Docker local development.
         # For Docker, the ACE_OUTPUT_DIR environment variable should be set (e.g., to /app/outputs).

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@
 services:
   &name ace-step:
     build:
-      context: .
+      context: https://github.com/ace-step/ACE-Step.git 
       dockerfile: Dockerfile
     container_name: *name
     hostname: *name

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@
 services:
   &name ace-step:
     build:
-      context: https://github.com/ace-step/ACE-Step.git 
+      context: https://github.com/ace-step/ACE-Step.git
       dockerfile: Dockerfile
     container_name: *name
     hostname: *name

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@
 services:
   &name ace-step:
     build:
-      context: https://github.com/ace-step/ACE-Step.git
+      context: .
       dockerfile: Dockerfile
     container_name: *name
     hostname: *name
@@ -10,9 +10,11 @@ services:
     ports:
       - "7865:7865"
     volumes:
-      - ace-step-checkpoints:/app/checkpoints
-      - ace-step-outputs:/app/outputs
-      - ace-step-logs:/app/exps/logs
+      - ./checkpoints:/app/checkpoints
+      - ./outputs:/app/outputs
+      - ./logs:/app/logs
+    environment:
+      - ACE_OUTPUT_DIR=/app/outputs
     # command: python app.py --server_name 0.0.0.0 --port 7865 --share False --bf16 True --torch_compile True --device-id 0
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:7865/"]
@@ -29,11 +31,3 @@ services:
             - driver: nvidia
               count: all
               capabilities: ["compute", "utility", "graphics", "video"]
-
-volumes:
-  ace-step-checkpoints:
-    name: ace-step-checkpoints
-  ace-step-outputs:
-    name: ace-step-outputs
-  ace-step-logs:
-    name: ace-step-logs


### PR DESCRIPTION
This PR introduces two main improvements:

1.  **Enhanced Output Path Handling in `acestep/ui/components.py`**:
- The output directory for generated files (e.g., in Text2Music UI) is now determined by the `ACE_OUTPUT_DIR` environment variable.
- If `ACE_OUTPUT_DIR` is not set (e.g., in non-Docker local development), it defaults to a relative path (`./outputs`), making outputs appear in a directory relative to where the script is run.
- This change resolves issues for users running the application outside of Docker, as it avoids hardcoding the Docker-specific `/app/outputs` path and improves usability for local development.

1. **Docker Compose Configuration Updates (`docker-compose.yaml`)**:
- Bind Mounts for Data: Changed volume definitions to use relative path bind mounts (e.g., `./outputs:/app/outputs`, `./logs:/app/logs`, `./checkpoints:/app/checkpoints`) instead of Docker-managed named volumes. This makes outputs, logs, and checkpoints directly accessible in the project directory on the host, simplifying data management. 
- Environment Variable for Docker: Added the `ACE_OUTPUT_DIR=/app/outputs` environment variable to the Docker service. This ensures the application inside the container uses the correct path that aligns with the bind mounts and the updated Python code, directing outputs to the shared host directory.