### PR TITLE
Fixed lora trainer bug

### DIFF
--- a/trainer.py
+++ b/trainer.py
@@ -76,6 +76,7 @@ class Pipeline(LightningModule):
             except ImportError:
                 raise ImportError("Please install peft library to use LoRA training")
             with open(lora_config_path, encoding="utf-8") as f:
+                import json
                 lora_config = json.load(f)
             lora_config = LoraConfig(**lora_config)
             transformers.add_adapter(adapter_config=lora_config, adapter_name=adapter_name)
@@ -825,6 +826,7 @@ def main(args):
         dataset_path=args.dataset_path,
         checkpoint_dir=args.checkpoint_dir,
         adapter_name=args.exp_name,
+        lora_config_path=args.lora_config_path
     )
     checkpoint_callback = ModelCheckpoint(
         monitor=None,


### PR DESCRIPTION
fixed lora trainer bug


```bash
base) root@ubuntu22:~/ACE-Step# sh train.sh 
2025-05-15 22:59:11.221 | INFO     | acestep.pipeline_ace_step:load_checkpoint:153 - Load models from: /root/models/
Traceback (most recent call last):
  File "/root/ACE-Step/trainer.py", line 887, in <module>
    main(args)
  File "/root/ACE-Step/trainer.py", line 819, in main
    model = Pipeline(
            ^^^^^^^^^
  File "/root/ACE-Step/trainer.py", line 72, in __init__
    assert lora_config_path is not None, "Please provide a LoRA config path"
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: Please provide a LoRA config path
(base) root@ubuntu22:~/ACE-Step# vim trainer.py 
(base) root@ubuntu22:~/ACE-Step# sh train.sh 
2025-05-15 23:03:24.187 | INFO     | acestep.pipeline_ace_step:load_checkpoint:153 - Load models from: /root/models/
Traceback (most recent call last):
  File "/root/ACE-Step/trainer.py", line 888, in <module>
    main(args)
  File "/root/ACE-Step/trainer.py", line 819, in main
    model = Pipeline(
            ^^^^^^^^^
  File "/root/ACE-Step/trainer.py", line 79, in __init__
    lora_config = json.load(f)
                  ^^^^
UnboundLocalError: cannot access local variable 'json' where it is not associated with a value
```

Although my command argument provided lora_config_path, the Pipeline instance in the main function did not use it, resulting in an error. I added relevant code to facilitate passing the lora_config_path parameter.

