### PR TITLE
Enable gradient checkpointing

### DIFF
--- a/acestep/models/lyrics_utils/lyric_encoder.py
+++ b/acestep/models/lyrics_utils/lyric_encoder.py
@@ -1030,8 +1030,8 @@ class ConformerEncoder(torch.nn.Module):
         mask_pad: torch.Tensor,
     ) -> torch.Tensor:
         for layer in self.encoders:
-            xs, chunk_masks, _, _ = ckpt.checkpoint(
-                layer.__call__, xs, chunk_masks, pos_emb, mask_pad
+            xs, chunk_masks, _, _ = torch.utils.checkpoint.checkpoint(
+                layer.__call__, xs, chunk_masks, pos_emb, mask_pad, use_reentrant=False
             )
         return xs
 

--- a/trainer.py
+++ b/trainer.py
@@ -68,6 +68,7 @@ class Pipeline(LightningModule):
         acestep_pipeline.load_checkpoint(acestep_pipeline.checkpoint_dir)
 
         transformers = acestep_pipeline.ace_step_transformer.float().cpu()
+        transformers.enable_gradient_checkpointing()
 
         assert lora_config_path is not None, "Please provide a LoRA config path"
         if lora_config_path is not None:


### PR DESCRIPTION
This saves VRAM in training. The most naive way (do checkpoint at each layer) saves a lot of VRAM. It's also possible to do checkpoint every a few layers for a trade-off between time and space.

The signature of `diffusers.models.modeling_utils.ModelMixin._set_gradient_checkpointing` in recent versions of diffusers is different from that in your code, see https://github.com/huggingface/diffusers/blob/9836f0e000cfd826a7a5099002253ed2becc13e0/src/diffusers/models/modeling_utils.py#L1710 . I think there is no need to overload `_set_gradient_checkpointing` in your published code.

`use_reentrant=False` is recommended in recent versions of torch (>= 2.4). There is also no need to define `create_custom_forward`.