### PR TITLE
Set scheduler interval to step, and fewer warmup steps

### DIFF
--- a/trainer.py
+++ b/trainer.py
@@ -49,7 +49,7 @@ class Pipeline(LightningModule):
         ssl_coeff: float = 1.0,
         checkpoint_dir=None,
         max_steps: int = 200000,
-        warmup_steps: int = 4000,
+        warmup_steps: int = 10,
         dataset_path: str = "./data/your_dataset_path",
         lora_config_path: str = None,
         adapter_name: str = "lora_adapter",
@@ -440,7 +440,7 @@ class Pipeline(LightningModule):
         lr_scheduler = torch.optim.lr_scheduler.LambdaLR(
             optimizer, lr_lambda, last_epoch=-1
         )
-        return [optimizer], lr_scheduler
+        return [optimizer], [{"scheduler": lr_scheduler, "interval": "step"}]
 
     def train_dataloader(self):
         self.train_dataset = Text2MusicDataset(


### PR DESCRIPTION
If we don't set `"interval": "step"`, then the lightning trainer will run `lr_scheduler.step()` every epoch, and the warmup will take 4000 epochs.

Also I think 4000 steps are too much. The purpose of the warmup is to avoid the unstable gradients before the Adam optimizer builds stable estimations of the momentum and the 2-norm. When training LoRA with not many trainable parameters (~10M), and not very large betas (0.8, 0.9), I think 10 steps are enough, and then we can quickly see the effect of training.