### PR TITLE
split out training packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,4 +24,11 @@ setup(
     package_data={
         "acestep.models.lyrics_utils": ["vocab.json"],  # Specify the relative path to vocab.json
     },
+    extras_require={
+        "train": [
+            "peft",
+            "tensorboard",
+            "tensorboardX"
+        ]
+    },
 )


### PR DESCRIPTION
This enables `pip install ace_step[train]`
I did this non-destructively so that it does not affect current requirements.txt, but in the future requirements.txt should exclude those packages so that `pip install ace_step` does not install training by default.