### PR TITLE
bump version due to new features

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     description="ACE Step: A Step Towards Music Generation Foundation Model",
     long_description=open("README.md", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
-    version="0.1.2",
+    version="0.2.0",
     packages=find_namespace_packages(),
     install_requires=open("requirements.txt", encoding="utf-8").read().splitlines(),
     author="ACE Studio, StepFun AI",


### PR DESCRIPTION
when installing the package, not updating the version number causes pip not to install the update