### PR TITLE
device-map test

### DIFF
--- a/acestep/cpu_offload.py
+++ b/acestep/cpu_offload.py
@@ -19,7 +19,7 @@ class CpuOffloader:
             self.model.to("cpu")
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
-            torch.cuda.synchronize()
+            # torch.cuda.synchronize()
 
 
 T = TypeVar('T')
@@ -31,8 +31,8 @@ def cpu_offload(model_attr: str):
             if not self.cpu_offload:
                 return func(self, *args, **kwargs)
 
-            # Get the device from the class
-            device = self.device
+            # Get the device from the class device map
+            device = getattr(self, "device_map", {}).get(model_attr, self.device)
             # Get the model from the class attribute
             model = getattr(self, model_attr)
             

--- a/acestep/music_dcae/music_dcae_pipeline.py
+++ b/acestep/music_dcae/music_dcae_pipeline.py
@@ -118,6 +118,7 @@ class MusicDCAE(ModelMixin, ConfigMixin, FromOriginalModelMixin):
         pred_wavs = []
 
         for latent in latents:
+            latent = latent.to(self.device)
             mels = self.dcae.decoder(latent.unsqueeze(0))
             mels = mels * 0.5 + 0.5
             mels = mels * (self.max_mel_value - self.min_mel_value) + self.min_mel_value


### PR DESCRIPTION
#32 for @nullnuller

This is an initial draft, further testing by different users is required. The code can also be written more elegantly, but this should be a robust way to see if it works and how good is the performance of this approach.

The code aims to 1. bring input tensors to self.ace_step_transformer.device and then bring the output tensors to self.device for each { ace_step_transformer, music_dcae, text_encoder_model }
It modifies cpu offload to follow the rules of self.device_map

Example device_map:
```python
device_map = {
    'ace_step_transformer': "cuda:0",
    'text_encoder_model': "cuda:1",
    'music_dcae': "cuda:1",
}
```