### PR TITLE
Use sox backend for ogg

### DIFF
--- a/acestep/pipeline_ace_step.py
+++ b/acestep/pipeline_ace_step.py
@@ -1393,9 +1393,12 @@ class ACEStepPipeline:
                 output_path_wav = save_path
 
         target_wav = target_wav.float()
-        logger.info(f"Saving audio to {output_path_wav}")
+        backend = "soundfile"
+        if format == "ogg":
+            backend = "sox"
+        logger.info(f"Saving audio to {output_path_wav} using backend {backend}")
         torchaudio.save(
-            output_path_wav, target_wav, sample_rate=sample_rate, format=format
+            output_path_wav, target_wav, sample_rate=sample_rate, format=format, backend=backend
         )
         return output_path_wav
 


### PR DESCRIPTION
There is an issue when saving audio as OGG. It crashes if the resulting file is "too big" which is >600 KB or so. Short songs are saved normally but anything long, like 2-3 minutes, causes a segmentation fault in `libsndfile_x86_64.so`. Relevant bug reports in libsndfile date back to 2014 (quoted in 2021):
https://lists.debian.org/debian-multimedia/2021/01/msg00124.html
https://github.com/bastibe/python-soundfile/issues/375
https://github.com/bastibe/python-soundfile/issues/396

There's no fix for libsndfile that I could find. So instead I propose switching the torchaudio backend to libsox (for OGG only) which works fine. This requires `libsox` to be installed in the user's system, otherwise torchaudio doesn't recognize the backend. It can be installed with `conda install sox` or `apt install libsox3` etc. depending on how you set up your environment. The python library `soxr` that is pulled from requirements is NOT enough, unfortunately.

The actual problem could be anywhere in libsndfile, libvorbis, or torchaudio. From the bug report it seems to happen if a big chunk of audio is written at once, so while a program should never crash because of the arbitrary library user decision, it could be mitigated in torchaudio by chunking the audio first in the `.save` function. I guess trying to push a fix there is more hassle than it's worth so switching to a backend where this bug doesn't happen is easier for our purposes.