### PR TITLE
AceStep Fix requirements to pin transformers and peft versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ torch
 torchaudio
 torchvision
 tqdm
-transformers==4.50.0
+transformers==4.49.0
 py3langid==0.3.0
 hangul-romanize==0.1.0
 num2words==0.5.14
@@ -21,6 +21,6 @@ accelerate==1.6.0
 cutlet
 fugashi[unidic-lite]
 click
-peft
+peft==0.17.0
 tensorboard
 tensorboardX


### PR DESCRIPTION
Seen on Ubuntu 24 LTS + conda 25.9.1 + Python 3.11.14
* peft has moved beyond transformers and now needs to be pegged to 0.17.0
** transformers==4.49.0
** peft==0.17.0