### PR TITLE
Update requirements.txt to fix LORA Training conflicts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 datasets==3.4.1
-diffusers>=0.33.0
+diffusers>=0.36.0
 gradio
 librosa==0.11.0
 loguru==0.7.3
@@ -11,8 +11,9 @@ soundfile==0.13.1
 torch
 torchaudio
 torchvision
+torchcodec
 tqdm
-transformers==4.50.0
+transformers>=4.57.3
 py3langid==0.3.0
 hangul-romanize==0.1.0
 num2words==0.5.14
@@ -21,6 +22,6 @@ accelerate==1.6.0
 cutlet
 fugashi[unidic-lite]
 click
-peft
+peft>=0.18.0
 tensorboard
 tensorboardX


### PR DESCRIPTION
There were two issues encountered on a fresh install to LORA training:

1. Conflicts in dependency versions made trainer.py unable to load.
2. torchcodec needed when processing MP3's

---
Re: (1)

Fixed conflicting versions between diffusers, transformers, and peft, which is caused by having an unspecified version of peft in requirements.txt.  

Using the versions installed by requirements.txt, I was able to get through the errors by updating the versions to: diffusers 0.36.0 
peft 0.18.0 
transformers 4.57.3

---

Re: (2)

The error message below comes up in LORA training: 
```
TorchCodec is required for load_with_torchcodec. Please install torchcodec to use this function.
2026-01-06 06:59:58.584 | ERROR    | acestep.text2music_dataset:__getitem__:670 - Error in getting item 14315: Empty example idx=14315
```

To fix it, I simply added torchcodec